### PR TITLE
issue: Choices Field Export

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1847,9 +1847,9 @@ class ChoiceField extends FormField {
         if ($value && is_array($value)) {
             $selection = $value;
         } elseif (isset($choices[$value]))
-            $selection[] = $choices[$value];
-        elseif ($this->get('default'))
-            $selection[] = $choices[$this->get('default')];
+            $selection[$value] = $choices[$value];
+        elseif (($v=$this->get('default')) && isset($choices[$v]))
+            $selection[$v] = $choices[$v];
 
         return $selection;
     }


### PR DESCRIPTION
This addresses an issue where exporting a ticket with a Custom Choices
Field does not export the Custom Choice data. This is due to the
`ChoiceField::getChoice()` function that doesn’t add the correct `id` to
the `$selection` array. This updates the function to include the `id` in
the array so we can get the correct value later on.