### PR TITLE
Department Ticket Assignment Options

### DIFF
--- a/include/ajax.tasks.php
+++ b/include/ajax.tasks.php
@@ -288,7 +288,9 @@ class TasksAjaxAPI extends AjaxController {
                                     Q::all(array(
                                         'dept_access__dept__id__in' => $depts,
                                         Q::not(array('dept_access__dept__flags__hasbit'
-                                            => Dept::FLAG_ASSIGN_MEMBERS_ONLY))
+                                            => Dept::FLAG_ASSIGN_MEMBERS_ONLY,
+                                            'dept_access__dept__flags__hasbit'
+                                                => Dept::FLAG_ASSIGN_PRIMARY_ONLY))
                                         ))
                                     )));
                 }

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -735,7 +735,9 @@ function refer($tid, $target=null) {
                                         Q::all(array(
                                             'dept_access__dept__id__in' => $depts,
                                             Q::not(array('dept_access__dept__flags__hasbit'
-                                                => Dept::FLAG_ASSIGN_MEMBERS_ONLY))
+                                                => Dept::FLAG_ASSIGN_MEMBERS_ONLY,
+                                                'dept_access__dept__flags__hasbit'
+                                                    => Dept::FLAG_ASSIGN_PRIMARY_ONLY))
                                             ))
                                         )));
                     }

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -648,7 +648,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             $errors['err'] = __('Unknown assignee');
         } elseif (!$assignee->isAvailable()) {
             $errors['err'] = __('Agent is unavailable for assignment');
-        } elseif ($dept->assignMembersOnly() && !$dept->isMember($assignee)) {
+        } elseif (!$dept->canAssign($assignee)) {
             $errors['err'] = __('Permission denied');
         }
 
@@ -692,6 +692,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         $evd = array();
         $assignee = $form->getAssignee();
         if ($assignee instanceof Staff) {
+            $dept = $this->getDept();
             if ($this->getStaffId() == $assignee->getId()) {
                 $errors['assignee'] = sprintf(__('%s already assigned to %s'),
                         __('Task'),
@@ -699,7 +700,10 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                         );
             } elseif(!$assignee->isAvailable()) {
                 $errors['assignee'] = __('Agent is unavailable for assignment');
-            } else {
+              } elseif (!$dept->canAssign($assignee)) {
+                $errors['err'] = __('Permission denied');
+            }
+            else {
                 $this->staff_id = $assignee->getId();
                 if ($thisstaff && $thisstaff->getId() == $assignee->getId())
                     $evd['claim'] = true;

--- a/include/i18n/en_US/help/tips/staff.department.yaml
+++ b/include/i18n/en_US/help/tips/staff.department.yaml
@@ -77,10 +77,9 @@ group_membership:
 sandboxing:
     title: Ticket Assignment Restrictions
     content: >
-        Enable this to restrict ticket assignment to include only members
-        of this Department. Department membership can be extended to Groups,
-        if <span class="doc-desc-title">Alerts &amp; Notices
-        Recipients</span> includes groups members.
+        Determine if Tickets can be assigned to all agents,
+        agents with Primary or Extended Department access,
+        or only agents with Primary Department access.
 
 disable_auto_claim:
     title: Disable Auto Claim

--- a/include/staff/department.inc.php
+++ b/include/staff/department.inc.php
@@ -167,17 +167,16 @@ $info = Format::htmlchars(($errors && $_POST) ? $_POST : $info);
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Ticket Assignment'); ?>:</td>
+          <td><?php echo __('Ticket Assignment'); ?>:</td>
             <td>
-                <label>
-                <input type="checkbox" name="assign_members_only" <?php echo
-                $info['assign_members_only']?'checked="checked"':''; ?>>
-                <?php echo __('Restrict ticket assignment to department members'); ?>
-                </label>
-                <i class="help-tip icon-question-sign" href="#sandboxing"></i>
+                <select name="assignment_flag">
+                  <option value="all"<?php echo ($info['assignment_flag'] == 'all')?'selected="selected"':'';?>><?php echo __('All'); ?></option>
+                  <option value="members"<?php echo ($info['assignment_flag'] == 'members') ?'selected="selected"':'';?>><?php echo __('Department Members'); ?></option>
+                  <option value="primary"<?php echo ($info['assignment_flag'] == 'primary') ?'selected="selected"':'';?>><?php echo __('Primary Members'); ?></option>
+                </select>
+                &nbsp;<span class="error">&nbsp;</span> <i class="help-tip icon-question-sign" href="#sandboxing"></i>
             </td>
         </tr>
-
         <tr>
             <td><?php echo __('Claim on Response'); ?>:</td>
             <td>


### PR DESCRIPTION
This commit extends Ticket Assignment options to allow Admins to decide which Agents can be assigned to Tickets for specific Departments. The Agents that appear for assignment can be all Agents, Department Agents (Extended or Primary access), or Primary Agents (Primary Department only, no Extended access).