### PR TITLE
Issue: Agent Export Department Status

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -254,7 +254,7 @@ class Export {
         $filename = $filename ?: sprintf('Agents-%s.csv',
                 strftime('%Y%m%d'));
         Http::download($filename, "text/$how");
-        $depts = Dept::getDepartments();
+        $depts = Dept::getDepartments(null, true, Dept::DISPLAY_DISABLED);
         echo self::dumpQuery($agents, array(
                     '::getName'  =>  'Name',
                     '::getUsername' => 'Username',


### PR DESCRIPTION
This commit changes the Agent export to display (disabled) beside the name of Departments on the export if they are Archived or Disabled. This will help Agents determine if an Agent is not assigned to any active Departments.