### PR TITLE
Agent Ticket on Behalf of User Fix 2:

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1367,8 +1367,8 @@ implements RestrictedAccess, Threadable, Searchable {
         return false;
     }
 
-    function checkReply($userType, $replyType) {
-      if ($userType == 'cc' && $replyType == 'reply-all')
+    function checkReply($userType, $replyType, $forceAlert=false) {
+      if ($userType == 'cc' && ($replyType == 'reply-all' || $forceAlert))
         return true;
 
       if ($userType == 'user' && ($replyType == 'reply-all' || $replyType == 'reply-user'))
@@ -2939,7 +2939,7 @@ implements RestrictedAccess, Threadable, Searchable {
             $attachments = $cfg->emailAttachments() ? $response->getAttachments() : array();
             //Cc collaborators
             $collabsCc = array();
-            if ($vars['ccs'] && Ticket::checkReply('cc', $vars['emailreply'])) {
+            if ($vars['ccs'] && Ticket::checkReply('cc', $vars['emailreply'], true)) {
                 $collabsCc[] = Collaborator::getCollabList($vars['ccs']);
                 $collabsCc['cc'] = $collabsCc[0];
             }
@@ -4045,7 +4045,7 @@ implements RestrictedAccess, Threadable, Searchable {
             $vars['response'] = $ticket->replaceVars($vars['response']);
             // $vars['cannedatachments'] contains the attachments placed on
             // the response form.
-            $response = $ticket->postReply($vars, $errors, is_null($vars['emailreply']) ?: !isset($vars['emailreply']));
+            $response = $ticket->postReply($vars, $errors, is_null($vars['emailreply']) ?: $vars['emailreply'] === "0");
         }
 
         // Not assigned...save optional note if any


### PR DESCRIPTION
This commit fixes an issue when an Agent creates a Ticket on behalf of a User, includes an Initial Response, AND chooses 'Do Not Send Alert' for the Ticket Notice. In this instance, ONLY the Agent's initial response should be sent to the Ticket's User and Collaborators so that they will know they are included in a Ticket.

In order for this logic to work, a literal check had to be done. If the emailreply variable is set to the string literal 0 (which means do not send alert was selected), say that the alert variable in postReply is true so that the Response/Reply template will go out with only the initial Agent response. Otherwise, if emailreply is 'Alert User' or 'Alert All', the alert variable in postReply will be false and the New Ticekt Notice template will go out, showing both the user initial message and the agent initial response.