### PR TITLE
issue: Queue Export Sorting

### DIFF
--- a/include/staff/templates/queue-export.tmpl.php
+++ b/include/staff/templates/queue-export.tmpl.php
@@ -39,7 +39,7 @@ if (isset($cache['fields']) && $fields)
       </tbody>
       <tbody class="sortable-rows" id="fields">
         <?php
-        foreach ($queue->getExportableFields() as $path  => $label) {
+        foreach (array_merge($fields, $queue->getExportableFields()) as $path  => $label) {
          echo sprintf('<tr style="display: table-row;">
                 <td><i class="faded-more
                 icon-sort"></i>&nbsp;&nbsp;<label><input


### PR DESCRIPTION
This addresses an issue where the Queue Export does not remember your
column sorting. This was due to the `getExportableFields()` function
called in the Export Template that gets a predefined list of fields plus
some `cdata` fields with a predefined sort order (not your saved sort
order). This updates the export template to merge the `$fields` array that
contains the exportable fields in the saved sorting order and the
`getExportableFields()` result (array) that contains the same fields plus
`cdata` fields. This will return the fields in the saved sorting order
whilst still displaying possible `cdata` fields.