### PR TITLE
issue: Limit Ticket Access Via URL

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -292,11 +292,11 @@ implements RestrictedAccess, Threadable, Searchable {
         // check department access first
         if (!$staff->canAccessDept($this->getDept())
                 // no restrictions
-                && !$staff->isAccessLimited()
+                || (!$staff->isAccessLimited()
                 // check assignment
                 && !$this->isAssigned($staff)
                 // check referral
-                && !$this->thread->isReferred($staff))
+                && !$this->thread->isReferred($staff)))
             return false;
 
         // At this point staff has view access unless a specific permission is


### PR DESCRIPTION
This addresses issue 4321 where an Agent is able to change the `id=` param
for `scp/tickets.php` and get access to tickets not in their Department.
They can only post Internal Notes and all options like Transfer, Assign,
etc. are Disabled but they still get View access though. So this updates
the `checkStaffPerm()` check to fail if the Agent does not have access to
the Department the ticket is under.