### PR TITLE
typo: Template Patch

### DIFF
--- a/include/upgrader/streams/core/70921d5c-26fd79dc.patch.sql
+++ b/include/upgrader/streams/core/70921d5c-26fd79dc.patch.sql
@@ -22,7 +22,7 @@ UPDATE `%TABLE_PREFIX%role`
 
 -- Ticket Notice Template
 UPDATE `%TABLE_PREFIX%email_template`
-    SET `code_name` = REPLACE('ticket.notice', '%{message}', '%{message}<br><br>%{response}')
+    SET `body` = REPLACE(`body`, '%{message}', '%{message}<br><br>%{response}')
     WHERE `code_name` = 'ticket.notice';
 
  -- Finished with patch


### PR DESCRIPTION
This addresses an issue where there was a typo in the latest template patch causing an unsuccessful run.