### PR TITLE
Collaborator Tickets Visibility:

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -197,6 +197,7 @@ class OsticketConfig extends Config {
         'agent_name_format' =>  'full', # First Last
         'client_name_format' => 'original', # As entered
         'auto_claim_tickets'=>  true,
+        'collaborator_ticket_visibility' =>  true,
         'system_language' =>    'en_US',
         'default_storage_bk' => 'D',
         'message_autoresponder_collabs' => true,
@@ -919,6 +920,10 @@ class OsticketConfig extends Config {
         return $this->get('auto_claim_tickets');
     }
 
+    function collaboratorTicketsVisibility() {
+        return $this->get('collaborator_ticket_visibility');
+    }
+
     function getDefaultTicketQueueId() {
         return $this->get('default_ticket_queue');
     }
@@ -1271,6 +1276,7 @@ class OsticketConfig extends Config {
             'max_open_tickets'=>$vars['max_open_tickets'],
             'enable_captcha'=>isset($vars['enable_captcha'])?1:0,
             'auto_claim_tickets'=>isset($vars['auto_claim_tickets'])?1:0,
+            'collaborator_ticket_visibility'=>isset($vars['collaborator_ticket_visibility'])?1:0,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],

--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -77,7 +77,11 @@ if ($settings['status'])
 // unique values
 $visibility = $basic_filter->copy()
     ->values_flat('ticket_id')
-    ->filter(array('user_id' => $thisclient->getId()))
+    ->filter(array('user_id' => $thisclient->getId()));
+
+// Add visibility of Tickets where the User is a Collaborator if enabled
+if ($cfg->collaboratorTicketsVisibility())
+    $visibility = $visibility
     ->union($basic_filter->copy()
         ->values_flat('ticket_id')
         ->filter(array('thread__collaborators__user_id' => $thisclient->getId()))

--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -67,6 +67,7 @@ core:
     assigned_alert_team_lead: 0
     assigned_alert_team_members: 0
     auto_claim_tickets: 1
+    collaborator_ticket_visibility: 1
     show_related_tickets: 1
     show_assigned_tickets: 1
     show_answered_tickets: 0

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -94,6 +94,15 @@ claim_tickets:
         <br><br>
         Reopened tickets are always assigned to the last respondent.
 
+collaborator_ticket_visibility:
+    title: Collaborator Tickets Visibility
+    content: >
+        If Enabled, Users will have visibility to ALL Tickets they participate in
+        when signing into the Web Portal.
+        <br><br>
+        If Disabled, Users will only be able to see their own Tickets
+        when signing into the Web Portal.
+
 assigned_tickets:
     title: Assigned Tickets
     content: >

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -207,6 +207,13 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td><?php echo __('Collaborator Tickets Visibility'); ?>:</td>
+            <td>
+                <input type="checkbox" name="collaborator_ticket_visibility" <?php echo $config['collaborator_ticket_visibility']?'checked="checked"':''; ?>>
+                <?php echo __('Enable'); ?>&nbsp;<i class="help-tip icon-question-sign" href="#collaborator_ticket_visibility"></i>
+            </td>
+        </tr>
+        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Attachments');?></b>:  <?php echo __('Size and maximum uploads setting mainly apply to web tickets.');?></em>
             </th>


### PR DESCRIPTION
This feature gives Agents the capability deciding whether or not Users should be able to see Tickets to which they are Collaborators for in their Ticket queues.

By default, Users are able to see all Tickets they take part in whether they are the User for the Ticket or a Collaborator.

If the Agent would like to disable Users seeing their Collaborator Tickets, they can configure the setting here:
Admin Panel | Tickets | Settings | Collaborator Tickets Visibility