### PR TITLE
thread: getId On Non-Object

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2863,7 +2863,8 @@ implements TemplateVariable {
     function addResponse($vars, &$errors) {
         $vars['threadId'] = $this->getId();
         $vars['userId'] = 0;
-        $vars['pid'] = $this->getLastMessage()->getId();
+        if ($message = $this->getLastMessage())
+            $vars['pid'] = $message->getId();
 
         $vars['flags'] = 0;
         switch ($vars['reply-to']) {


### PR DESCRIPTION
This addresses issue 4347 where opening a ticket without an initial message for the User and replying to it as an agent, fatally errors. This is because osTicket does not check if there is a last message before getting the ID from it.