### PR TITLE
 Collaborator Fixes

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -2073,11 +2073,14 @@ class ThreadEvents extends InstrumentedList {
     function log($object, $state, $data=null, $user=null, $annul=null) {
         global $thisstaff, $thisclient;
 
-        if ($object instanceof Ticket)
+        if ($object && ($object instanceof Ticket))
             // TODO: Use $object->createEvent() (nolint)
             $event = ThreadEvent::forTicket($object, $state, $user);
-        elseif ($object instanceof Task)
+        elseif ($object && ($object instanceof Task))
             $event = ThreadEvent::forTask($object, $state, $user);
+
+        if (is_null($event))
+            return;
 
         # Annul previous entries if requested (for instance, reopening a
         # ticket will annul an 'closed' entry). This will be useful to

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1505,8 +1505,18 @@ implements TemplateVariable {
         ));
 
         //add recipients to thread entry
-        if ($vars['thread_entry_recipients'])
+        if ($vars['thread_entry_recipients']) {
+            $count = 0;
+            foreach ($vars['thread_entry_recipients'] as $key => $value)
+                $count = $count + count($value);
+
+            if ($count > 1)
+                $entry->flags |= ThreadEntry::FLAG_REPLY_ALL;
+            else
+                $entry->flags |= ThreadEntry::FLAG_REPLY_USER;
+
             $entry->recipients = json_encode($vars['thread_entry_recipients']);
+        }
 
 
         if (Collaborator::getIdByUserId($vars['userId'], $vars['threadId']))
@@ -2866,14 +2876,6 @@ implements TemplateVariable {
         $vars['pid'] = $this->getLastMessage()->getId();
 
         $vars['flags'] = 0;
-        switch ($vars['reply-to']) {
-            case 'all':
-                $vars['flags'] |= ThreadEntry::FLAG_REPLY_ALL;
-            break;
-            case 'user':
-                $vars['flags'] |= ThreadEntry::FLAG_REPLY_USER;
-            break;
-        }
 
         if (!($resp = ResponseThreadEntry::add($vars, $errors)))
             return $resp;


### PR DESCRIPTION
- Fix for ‘creating default object from empty value’ message
- Add collaborators in the Ticket::create function instead of Ticket::open so that we can getRecipients in postMessage function
- Add relevant thread_entry_recipients in postMessage function for front end tickets (scp or Web Portal)
- Put the recipient icon (for one recipient or multiple) on Thread Entries created by Users
- Store email recipients so you can view them in the Thread Entry Actions