### PR TITLE
issue: IE White Screen Of Death

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -1286,12 +1286,12 @@ $(function() {
   $('#collabselection').select2({
     width: '350px',
     allowClear: true,
-    sorter: (data) => {
+    sorter: function(data) {
         return data.filter(function (item) {
                 return !item.selected;
                 });
     },
-    templateResult: (e) => {
+    templateResult: function(e) {
         var $e = $(
         '<span><i class="icon-user"></i> ' + e.text + '</span>'
         );


### PR DESCRIPTION
This addresses an issue on the forums where clicking to view the ticket as an Agent in IE 11 throws a white screen of death. This is due to the shorthand javascript arrow functions in `include/staff/ticket-view.inc.php`.