### PR TITLE
Help Topic Inline Save Fix:

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1006,12 +1006,16 @@ implements RestrictedAccess, Threadable, Searchable {
                         ));
             break;
         case 'topic':
+            $current = array();
+            if ($topic = $this->getTopic())
+                $current = array($topic->getId());
+            $choices = Topic::getHelpTopics(false, $topic ? (Topic::DISPLAY_DISABLED) : false, true, $current);
             return ChoiceField::init(array(
                         'id' => $fid,
                         'name' => "{$fid}_id",
                         'label' => __('Help Topic'),
                         'default' => $this->getTopicId(),
-                        'choices' => Topic::getHelpTopics(false, Topic::DISPLAY_DISABLED)
+                        'choices' => $choices
                         ));
             break;
         case 'source':
@@ -3338,7 +3342,7 @@ implements RestrictedAccess, Threadable, Searchable {
                     }
                 }
 
-                if (!$this->save())
+                if (!$errors && !$this->save())
                     $errors['field'] =  __('Unable to update field');
             }
         }

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -329,7 +329,7 @@ implements TemplateVariable, Searchable {
             $this->flags &= ~$flag;
     }
 
-    static function getHelpTopics($publicOnly=false, $disabled=false, $localize=true) {
+    static function getHelpTopics($publicOnly=false, $disabled=false, $localize=true, $whitelist=array()) {
       global $cfg;
       static $topics, $names = array();
 
@@ -385,7 +385,8 @@ implements TemplateVariable, Searchable {
           $info = $topics[$id];
           if ($publicOnly && !$info['public'])
               continue;
-          if (!$disabled && $info['disabled'])
+          //if topic is disabled + we're not getting all topics OR topic is not in whitelist
+          if ($info['disabled'] && (!$disabled || ($whitelist && !in_array($id, $whitelist))))
               continue;
           if ($disabled === self::DISPLAY_DISABLED && $info['disabled'])
               $n .= " - ".__("(disabled)");


### PR DESCRIPTION
This commit makes sure that if a Help Topic is disabled for a Ticket, it is the only disabled Help Topic that shows up in the list for Inline Edits.