### PR TITLE
2FA Modifications

### DIFF
--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -307,13 +307,16 @@ class StaffAjaxAPI extends AjaxController {
     }
 
     function reset2fA($staffId) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, 'Agent login required');
+        if (!$thisstaff->isAdmin())
+            Http::response(403, 'Access denied');
+
         $default_2fa = ConfigItem::getConfigsByNamespace('staff.'.$staffId, 'default_2fa');
-        $config = ConfigItem::getConfigsByNamespace('staff.'.$staffId, $default_2fa->value);
 
         if ($default_2fa)
             $default_2fa->delete();
-
-        if ($config)
-            $config->delete();
     }
 }

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -305,4 +305,15 @@ class StaffAjaxAPI extends AjaxController {
 
         include STAFFINC_DIR . 'templates/2fas.tmpl.php';
     }
+
+    function reset2fA($staffId) {
+        $default_2fa = ConfigItem::getConfigsByNamespace('staff.'.$staffId, 'default_2fa');
+        $config = ConfigItem::getConfigsByNamespace('staff.'.$staffId, $default_2fa->value);
+
+        if ($default_2fa)
+            $default_2fa->delete();
+
+        if ($config)
+            $config->delete();
+    }
 }

--- a/include/ajax.staff.php
+++ b/include/ajax.staff.php
@@ -278,11 +278,17 @@ class StaffAjaxAPI extends AjaxController {
                     $vars = $_POST ?: $config['config'] ?: array('email' => $staff->getEmail());
                     $form = $auth->getSetupForm($vars);
                     if ($_POST && $form && $form->isValid()) {
+                        if ($config['config'] && $config['config']['external2fa'])
+                            $external2fa = true;
+
                         // Save the setting based on setup form
                         $clean = $form->getClean();
-                        $config = ['config' => $clean, 'verified' => 0];
-                        $staff->updateConfig(array(
-                                    $auth->getId() => JsonDataEncoder::encode($config)));
+                        if (!$external2fa) {
+                            $config = ['config' => $clean, 'verified' => 0];
+                            $staff->updateConfig(array(
+                                        $auth->getId() => JsonDataEncoder::encode($config)));
+                        }
+
                         // Send verification token to the user
                         if ($token=$auth->send($staff)) {
                             // Transition to verify state
@@ -291,7 +297,7 @@ class StaffAjaxAPI extends AjaxController {
                             $info['notice'] = __('Token sent to you!');
                         } else {
                             // Generic error TODO: better wording
-                            $info['error'] = __('Error sending Token - doubdle check entry');
+                            $info['error'] = __('Error sending Token - double check entry');
                         }
                     }
             }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -186,6 +186,23 @@ extends VerySimpleModel {
                 'updated__lt' => SqlFunction::NOW()->minus(SqlInterval::SECOND($period)),
             ))->delete();
     }
+
+    function getConfigsByNamespace($namespace=false, $key, $value=false) {
+        $filter = array();
+
+         $filter['key'] = $key;
+
+         if ($namespace)
+            $filter['namespace'] = $namespace;
+
+         if ($value)
+            $filter['value'] = $value;
+
+         $token = ConfigItem::objects()
+            ->filter($filter);
+
+         return $namespace ? $token[0] : $token;
+    }
 }
 
 class OsticketConfig extends Config {

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -389,6 +389,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         return $this->change_passwd;
     }
 
+    function force2faConfig() {
+        global $cfg;
+
+        return ($cfg->require2FAForAgents() && !$this->get2FABackend());
+    }
+
     function getDepartments() {
         // TODO: Cache this in the agent's session as it is unlikely to
         //       change while logged in

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -193,17 +193,6 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
             JsonDataParser::decode($config[$id]) : array();
     }
 
-    function is2FAConfigured($id) {
-        $config = $this->getConfig();
-
-        if (isset($config[$id])) {
-           $config = json_decode($config[$id], true);
-           return array_key_exists('verified', $config);
-        }
-
-        return false;
-    }
-
     function setAuthKey($key) {
         $this->authkey = $key;
     }
@@ -404,12 +393,12 @@ implements AuthenticatedUser, EmailContact, TemplateVariable, Searchable {
         global $cfg;
 
         $id = $this->get2FABackendId();
-        $config = ConfigItem::getConfigsByNamespace('staff.'.$this->getId(), $id);
+        $config = $this->get2FAConfig($id);
 
         //2fa is required and
         //1. agent doesn't have default_2fa or
         //2. agent has default_2fa, but that default_2fa is not configured
-        return ($cfg->require2FAForAgents() && !$id || ($id && is_null($config)));
+        return ($cfg->require2FAForAgents() && !$id || ($id && empty($config)));
     }
 
     function getDepartments() {

--- a/include/i18n/en_US/help/tips/dashboard.my_profile.yaml
+++ b/include/i18n/en_US/help/tips/dashboard.my_profile.yaml
@@ -27,6 +27,14 @@ username:
       - title: Change a username as an Administrator
         href: /scp/staff.php
 
+config2fa:
+    title: Two Factor Authentication
+    content: >
+        Two Factor Authentication adds an extra layer of security
+        when logging into the helpdesk. Once you correctly submit
+        your username and password, you will need to enter a token
+        to finish logging into the helpdesk.
+
 time_zone:
     title: Time Zone
     content: >
@@ -83,11 +91,11 @@ confirm_new_password:
 signature:
     title: Signature
     content: >
-        Create an optional <span class="doc-desc-title">Signature</span> 
-        that perhaps appears at the end of your Ticket Responses. Whether this 
-        <span class="doc-desc-title">Signature</span> appears, or not, depends 
-        on the <span class="doc-desc-title">Email Template</span> that will be 
-        used in a Ticket Response. 
+        Create an optional <span class="doc-desc-title">Signature</span>
+        that perhaps appears at the end of your Ticket Responses. Whether this
+        <span class="doc-desc-title">Signature</span> appears, or not, depends
+        on the <span class="doc-desc-title">Email Template</span> that will be
+        used in a Ticket Response.
     links:
       - title: Create Emails Templates in the Admin Panel
         href: /scp/templates.php

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -78,3 +78,11 @@ bind_staff_session_to_ip:
         upon Log In.
         <br><br>
         This setting is not recommened for users assigned IP addresses dynamically.
+
+require_agent_2fa:
+     title: Require Two Factor Authentication
+     content: >
+         Enable this feature if you would like to have an extra layer of authentication
+         set up for Agents when they log into the helpdesk. Once they correctly submit
+         their username and password, they will be required to submit a token to finish
+         logging into the helpdesk.

--- a/include/i18n/en_US/help/tips/staff.agent.yaml
+++ b/include/i18n/en_US/help/tips/staff.agent.yaml
@@ -20,6 +20,14 @@ username:
         that is unique to your <span class="doc-desc-title">Help
         Desk</span>.
 
+reset2fa:
+    title: Reset Two Factor Authentication
+    content: >
+        In the event that an Agent loses the ability to log into the helpdesk
+        using their current 2FA configuration, an Admin can reset the Agent's
+        2FA configuration so that they can reconfigure it upon their next
+        successful login.
+
 email_address:
     title: Email Address
     content: >

--- a/include/i18n/en_US/templates/page/email2fa-staff.yaml
+++ b/include/i18n/en_US/templates/page/email2fa-staff.yaml
@@ -1,0 +1,24 @@
+#
+# email2fa-staff.yaml
+#
+# Template of the email sent to staff members when using the Email
+# Two Factor Authentication
+---
+notes: >
+    This template defines the email sent to Staff who use Email for
+    Two Factor Authentication
+name: "osTicket Two Factor Authentication"
+body: >
+    <h3><strong>Hi %{staff.name.first},</strong></h3>
+    <div>
+    You have just logged into for the helpdesk at %{url}.<br />
+    <br />
+    Use the verification code below to finish logging into the helpdesk.<br />
+    <br />
+    %{otp}<br />
+    <br />
+    <em style="font-size: small">Your friendly Customer Support System</em>
+    <br />
+    <img src="cid:b56944cb4722cc5cda9d1e23a3ea7fbc" alt="Powered by
+    osTicket" width="126" height="19" style="width: 126px" />
+    </div>

--- a/include/staff/login.tpl.php
+++ b/include/staff/login.tpl.php
@@ -18,6 +18,10 @@ if ($thisstaff && $thisstaff->is2FAPending())
     </a></h1>
     <h3 id="login-message"><?php echo Format::htmlchars($msg); ?></h3>
     <div class="banner"><small><?php echo ($content) ? Format::display($content->getLocalBody()) : ''; ?></small></div>
+    <div id="loading" style="display:none;" class="dialog">
+        <h1><i class="icon-spinner icon-spin icon-large"></i>
+        <?php echo __('Loading');?></h1>
+    </div>
     <form action="login.php" method="post" id="login" onsubmit="attemptLoginAjax(event)">
         <?php csrf_token();
         if ($thisstaff
@@ -87,6 +91,7 @@ if (count($ext_bks)) { ?>
     });
 
     function attemptLoginAjax(e) {
+        $('#loading').show();
         var objectifyForm = function(formArray) { //serialize data function
             var returnArray = {};
             for (var i = 0; i < formArray.length; i++) {
@@ -101,6 +106,7 @@ if (count($ext_bks)) { ?>
             var oldEffect = $.fn.effect;
             $.fn.effect = function (effectName) {
                 if (effectName === "shake") {
+                    $('#loading').hide();
                     var old = $.effects.createWrapper;
                     $.effects.createWrapper = function (element) {
                         var result;

--- a/include/staff/login.tpl.php
+++ b/include/staff/login.tpl.php
@@ -20,7 +20,7 @@ if ($thisstaff && $thisstaff->is2FAPending())
     <div class="banner"><small><?php echo ($content) ? Format::display($content->getLocalBody()) : ''; ?></small></div>
     <div id="loading" style="display:none;" class="dialog">
         <h1><i class="icon-spinner icon-spin icon-large"></i>
-        <?php echo __('Loading');?></h1>
+        <?php echo __('Verifying');?></h1>
     </div>
     <form action="login.php" method="post" id="login" onsubmit="attemptLoginAjax(event)">
         <?php csrf_token();

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -139,7 +139,8 @@ if (($bks=Staff2FABackend::allRegistered())) {
               <?php
               }
              foreach ($bks as $bk) {
-                 $configured = $staff->is2FAConfigured($bk->getId());
+                 $configuration = $staff->get2FAConfig($bk->getId());
+                 $configured = $configuration['verified'];
                  ?>
               <option id="<?php echo $bk->getId(); ?>"
                       value="<?php echo $bk->getId(); ?>" <?php

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -139,8 +139,7 @@ if (($bks=Staff2FABackend::allRegistered())) {
               <?php
               }
              foreach ($bks as $bk) {
-                 $configured = (isset($_config[$bk->getId()]) &&
-                     $_config[$bk->getId()]['verified']);
+                 $configured = $staff->is2FAConfigured($bk->getId());
                  ?>
               <option id="<?php echo $bk->getId(); ?>"
                       value="<?php echo $bk->getId(); ?>" <?php

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -142,7 +142,8 @@ if (($bks=Staff2FABackend::allRegistered())) {
                  $configured = (isset($_config[$bk->getId()]) &&
                      $_config[$bk->getId()]['verified']);
                  ?>
-              <option value="<?php echo $bk->getId(); ?>" <?php
+              <option id="<?php echo $bk->getId(); ?>"
+                      value="<?php echo $bk->getId(); ?>" <?php
                 if ($current == $bk->getId() && $configured)
                   echo ' selected="selected" '; ?>
                 <?php

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -223,6 +223,7 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                     <?php $manage_content(__('Agent Welcome Email'), 'registration-staff'); ?>
                     <?php $manage_content(__('Sign-in Login Banner'), 'banner-staff'); ?>
                     <?php $manage_content(__('Password Reset Email'), 'pwreset-staff'); ?>
+                    <?php $manage_content(__('Two Factor Authentication Email'), 'email2fa-staff'); ?>
                 </tbody>
             </table>
         </div>

--- a/include/staff/staff.inc.php
+++ b/include/staff/staff.inc.php
@@ -163,6 +163,35 @@ if (count($bks) > 1) {
         </tr>
 <?php
 } ?>
+<?php
+if ($bks=Staff2FABackend::allRegistered() && $current = $staff->get2FABackend()) {
+    $_config = $staff->getConfig();
+?>
+        <tr>
+          <td><?php echo __('Default 2FA'); ?>:</td>
+          <td>
+              <input type="text" size="40" style="width:300px"
+                name="default_2fa" disabled value="<?php echo $current->getName(); ?>" />
+            &nbsp;
+            <button type="button" id="reset-2fa" class="action-button" onclick="javascript:
+                if (confirm('<?php echo __('You sure?'); ?>')) {
+                    $.ajax({
+                        url: 'ajax.php/staff/'+<?php echo $staff->getId(); ?>+'/reset-2fa',
+                        type: 'POST',
+                        data: {'staffId':<?php echo $staff->getId(); ?>},
+                        success: function(data) {
+                            location.reload();
+                        }
+                    });
+                }
+                return false;">
+              <i class="icon-gear"></i> <?php echo __('Reset 2FA'); ?>
+            </button>
+            <i class="offset help-tip icon-question-sign" href="#reset2fa"></i>
+          </td>
+        </tr>
+<?php
+} ?>
       </tbody>
       <!-- ================================================ -->
       <tbody>

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -19,15 +19,10 @@ if ($info['error']) {
     <tbody>
       <?php
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
-          if ($isVerified = $staff->is2FAConfigured($bk->getId())) {
-          ?>
-          <script type="text/javascript">
-              isVerified = '<?php echo $isVerified;?>';
-              id = '<?php echo $id;?>';
-              enable2fa(isVerified, id);
-          </script>
-          <?php } ?>
-      <tr id="<?php echo $bk->getId(); ?>">
+          $configuration = $staff->get2FAConfig($bk->getId());
+          $isVerified = $configuration['verified'];
+          $vclass = $isVerified ? 'verified' : 'unverified'; ?>
+      <tr id="<?php echo $bk->getId(); ?>" class="2fa-type <?php echo $vclass; ?>">
         <td nowrap width="10px">
           <i class="faded-more <?php echo sprintf('icon-check-%s',
           $isVerified ? 'sign' : 'empty'); ?>"></i>
@@ -84,11 +79,12 @@ if ($auth && $form) {
 </div>
 <div class="clear"></div>
 <script type="text/javascript">
-function enable2fa(isVerified, id) {
-    document.getElementById(id).disabled=false;
-}
-
 $(function() {
+    var ids = $('.verified').map(function() {
+        id2fa = $(this).attr('id');
+        document.getElementById(id2fa).disabled=false;
+    });
+
     $('a.config2fa').click( function(e) {
         e.preventDefault();
         if ($(this).attr('href').length > 1) {

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -18,11 +18,8 @@ if ($info['error']) {
 <table class="table">
     <tbody>
       <?php
-      $config = $staff->getConfig();
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
-          $isVerified = (isset($config[$bk->getId()]) &&
-                  $config[$bk->getId()]['verified']);
-          if ($isVerified) {
+          if ($isVerified = $staff->is2FAConfigured($bk->getId())) {
           ?>
           <script type="text/javascript">
               isVerified = '<?php echo $isVerified;?>';
@@ -89,7 +86,6 @@ if ($auth && $form) {
 <script type="text/javascript">
 function enable2fa(isVerified, id) {
     document.getElementById(id).disabled=false;
-    document.getElementById(id).selected=true;
 }
 
 $(function() {

--- a/include/staff/templates/2fas.tmpl.php
+++ b/include/staff/templates/2fas.tmpl.php
@@ -22,7 +22,14 @@ if ($info['error']) {
       foreach (Staff2FABackend::allRegistered() ?: array() as $bk) {
           $isVerified = (isset($config[$bk->getId()]) &&
                   $config[$bk->getId()]['verified']);
+          if ($isVerified) {
           ?>
+          <script type="text/javascript">
+              isVerified = '<?php echo $isVerified;?>';
+              id = '<?php echo $id;?>';
+              enable2fa(isVerified, id);
+          </script>
+          <?php } ?>
       <tr id="<?php echo $bk->getId(); ?>">
         <td nowrap width="10px">
           <i class="faded-more <?php echo sprintf('icon-check-%s',
@@ -30,7 +37,7 @@ if ($info['error']) {
           <span data-name="label"></span>
         </td>
         <td width="300px">
-            <a class="config2fa" 
+            <a class="config2fa"
                 href="<?php echo sprintf('#staff/%d/2fa/configure/%s',
                 $staff->getId(), urlencode($bk->getId())); ?>"> <?php echo $bk->getName(); ?>
               </a>
@@ -55,8 +62,8 @@ if ($auth && $form) {
  <div><?php echo Format::htmlchars($instruction); ?></div>
  <br>
 <form class="bk" method="post" action="<?php echo sprintf('#staff/%d/2fa/configure/%s',
-    $staff->getId(), $auth->getId()); ?>">    
-    <input type="hidden" name="state" value="<?php 
+    $staff->getId(), $auth->getId()); ?>">
+    <input type="hidden" name="state" value="<?php
         echo $state ?: 'validate'; ?>" />
     <?php
     echo csrf_token();
@@ -80,6 +87,11 @@ if ($auth && $form) {
 </div>
 <div class="clear"></div>
 <script type="text/javascript">
+function enable2fa(isVerified, id) {
+    document.getElementById(id).disabled=false;
+    document.getElementById(id).selected=true;
+}
+
 $(function() {
     $('a.config2fa').click( function(e) {
         e.preventDefault();
@@ -107,4 +119,3 @@ $(function() {
 
 });
 </script>
-

--- a/include/staff/templates/navigation.tmpl.php
+++ b/include/staff/templates/navigation.tmpl.php
@@ -1,5 +1,5 @@
 <?php
-if(($tabs=$nav->getTabs()) && is_array($tabs)){
+if($nav && ($tabs=$nav->getTabs()) && is_array($tabs)){
     foreach($tabs as $name =>$tab) {
         if ($tab['href'][0] != '/')
             $tab['href'] = ROOT_PATH . 'scp/' . $tab['href'];

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -293,7 +293,8 @@ $dispatcher = patterns('',
         url('^/reset-permissions', 'resetPermissions'),
         url('^/change-department', 'changeDepartment'),
         url('^/(?P<id>\d+)/avatar/change', 'setAvatar'),
-        url('^/(?P<id>\d+)/2fa/configure(?:/(?P<mfid>.+))?$', 'configure2FA')
+        url('^/(?P<id>\d+)/2fa/configure(?:/(?P<mfid>.+))?$', 'configure2FA'),
+        url('^/(?P<id>\d+)/reset-2fa', 'reset2fA')
     )),
     url('^/queue/', patterns('ajax.search.php:SearchAjaxAPI',
         url('^(?P<id>\d+/)?preview$', 'previewQueue'),

--- a/scp/profile.php
+++ b/scp/profile.php
@@ -44,6 +44,15 @@ if($thisstaff->forcePasswdChange() && !$errors['err'])
             $thisstaff->getFirstName()
         )
     );
+elseif($thisstaff->force2faConfig() && !$errors['err'])
+    $errors['err'] = str_replace(
+        '<a>',
+        sprintf('<a data-dialog="ajax.php/staff/%d/2fa/configure" href="#">', $thisstaff->getId()),
+        sprintf(
+            __('<b>Hi %s</b> - You must <a>configure and save Two Factor Authentication </a>!'),
+            $thisstaff->getFirstName()
+        )
+    );
 elseif($thisstaff->onVacation() && !$warn)
     $warn=sprintf(__("<b>Welcome back %s</b>! You are listed as 'on vacation' Please let your manager know that you are back."),$thisstaff->getFirstName());
 

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -136,6 +136,10 @@ if($thisstaff->forcePasswdChange() && !$exempt) {
     $sysnotice = __('Password change required to continue');
     require('profile.php'); //profile.php must request this file as require_once to avoid problems.
     exit;
+} elseif ($thisstaff->force2faConfig() && !$exempt) {
+    $sysnotice = __('Two Factor Authentication configuration required to continue');
+    require('profile.php');
+    exit;
 }
 $ost->setWarning($sysnotice);
 $ost->setPageTitle(__('osTicket :: Staff Control Panel'));


### PR DESCRIPTION
This commit adds to the functionality of two factor authentication for osTicket.

- Ensures that we do not clear out external 2fa configurations
- Enables 2fa options in the dropdown box of the profile when they are configured
- Adds help tip to the Default 2FA field
- Forces Agents to configure and save 2FA if 'Require agents to turn on 2FA' is checked upon next login
- Fixes the following error:
	- Call to a member function getTabs() on null in include/staff/templates/navigation.tmpl.php